### PR TITLE
fix(index): run with older versions of node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const request = require('request')
 const xml2js = require('xml2js')
 


### PR DESCRIPTION
Older versions of node require `'use strict'` when using const/let/...